### PR TITLE
Specify GTNHMixins as required dependency

### DIFF
--- a/src/main/java/jss/bugtorch/BugTorch.java
+++ b/src/main/java/jss/bugtorch/BugTorch.java
@@ -25,7 +25,7 @@ import jss.bugtorch.modsupport.WitcherySupport;
 		name = BugTorch.NAME,
 		version = BugTorch.VERSION,
 		acceptableRemoteVersions = "*",
-		dependencies = "after:Thaumcraft;after:temperateplants;after:VillageNames;after:witchery;"
+		dependencies = "required-after:gtnhmixins@[2.0.0,);after:Thaumcraft;after:temperateplants;after:VillageNames;after:witchery;"
 	)
 public class BugTorch {
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -13,8 +13,8 @@
 		"logoFile": "",
 		"screenshots": [],
 		"parent": "",
-		"requiredMods": [],
-		"dependencies": ["Thaumcraft", "temperateplants", "VillageNames", "witchery"],
+		"requiredMods": ["gtnhmixins@[2.0.0,)"],
+		"dependencies": ["gtnhmixins@[2.0.0,)", "Thaumcraft", "temperateplants", "VillageNames", "witchery"],
 		"dependants": [],
 		"useDependencyInformation": true
 	}]

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -14,7 +14,7 @@
 		"screenshots": [],
 		"parent": "",
 		"requiredMods": [],
-		"dependencies": [],
+		"dependencies": ["Thaumcraft", "temperateplants", "VillageNames", "witchery"],
 		"dependants": [],
 		"useDependencyInformation": true
 	}]


### PR DESCRIPTION
The mod requires GTNHMixins, but can be launched without it, causing some weird behavior. This PR specifies it as a required dependency.

Having it in the `@Mod` annotation may be redundant since `useDependencyInformation` is set to true (which causes FML to refer to the mcmod.info to determine dependencies), but it shouldn't cause any harm at least.