### PR TITLE
Fixing crash caused by a Null in EntityItem mixin

### DIFF
--- a/src/main/java/jss/bugtorch/mixins/early/minecraft/optimization/MixinEntityItem.java
+++ b/src/main/java/jss/bugtorch/mixins/early/minecraft/optimization/MixinEntityItem.java
@@ -24,7 +24,7 @@ public abstract class MixinEntityItem extends Entity {
 	@Inject(method = "searchForOtherItemsNearby", at = @At("HEAD"), cancellable = true)
 	private void searchForOtherItemsNearbyHead(CallbackInfo ci) {
 		final ItemStack stack = getDataWatcher().getWatchableObjectItemStack(10);
-		if (stack.stackSize >= stack.getMaxStackSize()) {
+		if ( stack != null && stack.stackSize >= stack.getMaxStackSize()) {
 			ci.cancel();
 		}
 	}


### PR DESCRIPTION
A crash happened here https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14756 referencing the line that is changed in this pr. 
This is my proposed fix