### PR TITLE
lwjgl2 is saved 

### DIFF
--- a/src/main/java/jss/bugtorch/config/BugTorchConfig.java
+++ b/src/main/java/jss/bugtorch/config/BugTorchConfig.java
@@ -16,6 +16,7 @@ public class BugTorchConfig {
 	public static boolean fixPumpkinBlocksRandomlyTicking;
 	public static boolean fixSnowBlocksRandomlyTicking;
 	public static boolean fixTorchBlocksRandomlyTicking;
+    public static boolean fixLWJGL2OpenALCrash;
 
 	//Base tweaks
 	public static int showBroadcastSettingsButton;
@@ -236,8 +237,9 @@ public class BugTorchConfig {
 		fixVillagerTradeMetadataDetection = false; config.getBoolean("fixVillagerTradeMetadataDetection", categoryBugfixes, true, "Villager trades will respect metadata.\nCurrently unfinished and disabled internally.\nFrom MC 1.8");
 		fixVillageSieges = config.getBoolean("fixVillageSieges", categoryBugfixes, true, "Zombies will siege villages that are large enough at night.\nFrom MC 1.8, fixes MC-7432 and MC-7488");
 		fixVillageWellDesertMaterial = config.getBoolean("fixVillageWellDesertMaterial", categoryBugfixes, true, "Wells in desert villages will use the correct material.\nFrom MC 1.8, fixes MC-32514");
+        fixLWJGL2OpenALCrash = config.getBoolean("fixLWJGL2OpenALCrash", categoryBugfixes, true, "Fixes the ridiculous bug where the SoundSystem will consistently fail to re/initialize, commonly observed with LWJGL2 nightlies on Linux. Disabled when LWJGL3ify is present.");
 
-		//Performance
+        //Performance
 		brokenChestsDontSplitStacks = config.getBoolean("brokenChestsDontSplitStacks", categoryPerformance, false, "Broken chests don't split apart dropped item stacks.");
 		brokenHoppersDontSplitStacks = config.getBoolean("brokenHoppersDontSplitStacks", categoryPerformance, false, "Broken hoppers don't split apart dropped item stacks.");
 		fasterDroppedItemStackingChecks = config.getBoolean("fasterDroppedItemStackingChecks", categoryPerformance, true, "Dropped item nearby stack checks are faster for full stacks.");

--- a/src/main/java/jss/bugtorch/mixinplugin/BugTorchEarlyMixins.java
+++ b/src/main/java/jss/bugtorch/mixinplugin/BugTorchEarlyMixins.java
@@ -38,7 +38,7 @@ public class BugTorchEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoader
             BugTorch.logger.info("NotFine detected, skipping redundant early mixins.");
             useNotFineOverlap = false;
         }
-        
+
         txLoaderPresent = client && loadedCoreMods.contains("glowredman.txloader.TXLoaderCore");
 
         //Backports
@@ -133,6 +133,10 @@ public class BugTorchEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoader
         }
         if(BugTorchConfig.fixVillageWellDesertMaterial) {
             mixins.add("minecraft.worldgen.MixinStructureVillagePieces_Well");
+        }
+
+        if (client && BugTorchConfig.fixLWJGL2OpenALCrash && !(loadedCoreMods.contains("me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod"))) {
+            mixins.add("minecraft.fix.MixinSoundManager");
         }
 
         //Performance

--- a/src/main/java/jss/bugtorch/mixins/early/minecraft/fix/MixinSoundManager.java
+++ b/src/main/java/jss/bugtorch/mixins/early/minecraft/fix/MixinSoundManager.java
@@ -1,0 +1,15 @@
+package jss.bugtorch.mixins.early.minecraft.fix;
+
+import net.minecraft.client.audio.SoundManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SoundManager.class)
+public abstract class MixinSoundManager {
+    @Inject(method = "reloadSoundSystem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/audio/SoundManager;loadSoundSystem()V"))
+    public void snooze(CallbackInfo ctx) throws InterruptedException {
+        Thread.sleep(333);
+    }
+}


### PR DESCRIPTION
this fixes two issues at the same time, which mostly affect LWJGL2 users on Linux systems:
<details>
<summary>1. the common case where the game fails to reinitialize the OpenAL context and permanently goes into silent mode;</summary>

```
[Thread-11/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]: Initializing LWJGL OpenAL
[Thread-11/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]:     (The LWJGL binding of OpenAL.  For more information, see http://www.lwjgl.org)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: java.lang.IllegalStateException: Only one OpenAL context may be instantiated at any one time.
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.lwjgl.openal.AL.create(AL.java:113)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.lwjgl.openal.AL.create(AL.java:102)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.lwjgl.openal.AL.create(AL.java:206)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at paulscode.sound.libraries.LibraryLWJGLOpenAL.init(LibraryLWJGLOpenAL.java:164)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at paulscode.sound.SoundSystem.CommandNewLibrary(SoundSystem.java:1576)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at paulscode.sound.SoundSystem.CommandQueue(SoundSystem.java:2572)
[Thread-11/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at paulscode.sound.CommandThread.run(CommandThread.java:121)
Exception in thread "Thread-11" [Sound Library Loader/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:importantMessage:90]:     ERROR MESSAGE:
[Sound Library Loader/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]:         SoundSystem did not load after 30 seconds.
[Sound Library Loader/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]: 
[Sound Library Loader/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]: Starting up SoundSystem...
[Thread-14/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]: Switching to No Sound
[Thread-14/INFO] [STDOUT]: [paulscode.sound.SoundSystemLogger:message:69]:     (Silent Mode)
```
</details>
<details>
<summary>2. the less desirable case where the game doesn't go into silent mode and instead hard crashes, usually when the user is already loaded into a world</summary>

```
Description: Unexpected error

java.lang.UnsatisfiedLinkError: org.lwjgl.openal.AL10.nalGetSourcei(II)I
	at org.lwjgl.openal.AL10.nalGetSourcei(Native Method)
	at org.lwjgl.openal.AL10.alGetSourcei(AL10.java:853)
	at paulscode.sound.libraries.ChannelLWJGLOpenAL.playing(ChannelLWJGLOpenAL.java:651)
	at paulscode.sound.Source.playing(Source.java:1213)
	at net.minecraft.client.audio.SoundManager$SoundSystemStarterThread.playing(SoundManager.java:548)
	at net.minecraft.client.audio.SoundManager.updateAllSounds(SoundManager.java:245)
	at net.minecraft.client.audio.SoundHandler.update(SoundHandler.java:224)
```
</details>

it may not be pretty or smart but it WORKS IT WORKS IT WORKS AAAAAAAAAAHHHHHHHHHHHHHHHH